### PR TITLE
modeltool cleanup

### DIFF
--- a/src/Evaluate Model.ipynb
+++ b/src/Evaluate Model.ipynb
@@ -14,7 +14,13 @@
     }
    ],
    "source": [
-    "from model_tool import Model, compute_auc"
+    "from __future__ import absolute_import\n",
+    "from __future__ import division\n",
+    "from __future__ import print_function\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "from model_tool import ToxModel"
    ]
   },
   {
@@ -38,7 +44,7 @@
    "outputs": [],
    "source": [
     "# Load a pretrained model\n",
-    "m = Model(MODEL_NAME)"
+    "m = ToxModel(MODEL_NAME)"
    ]
   },
   {
@@ -59,7 +65,8 @@
    ],
    "source": [
     "# Prints out the AUC score\n",
-    "m.prep_data_and_score(TEST_DATA, text_column = 'comment', label_column = 'is_toxic')"
+    "test_data = pd.read_csv(TEST_DATA)\n",
+    "m.score_auc(test_data['comment'], test_data['is_toxic'])"
    ]
   },
   {
@@ -88,7 +95,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "version": "2.7.6"
   }
  },
  "nbformat": 4,

--- a/src/Train Toxicity Model.ipynb
+++ b/src/Train Toxicity Model.ipynb
@@ -34,9 +34,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HELLO from model_tool\n"
+     ]
+    },
     {
      "name": "stderr",
      "output_type": "stream",
@@ -46,6 +53,12 @@
     }
    ],
    "source": [
+    "from __future__ import absolute_import\n",
+    "from __future__ import division\n",
+    "from __future__ import print_function\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
     "from model_tool import ToxModel"
    ]
   },
@@ -58,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {
     "collapsed": true
    },
@@ -132,22 +145,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.96639960435082739"
+       "0.95864283651436777"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "debias_random_model.prep_data_and_score(random['test'], text_column = 'comment', label_column = 'is_toxic')"
+    "random_test = pd.read_csv(random['test'])\n",
+    "debias_random_model.score_auc(random_test['comment'], random_test['is_toxic'])"
    ]
   },
   {
@@ -208,7 +222,8 @@
     }
    ],
    "source": [
-    "wiki_model.prep_data_and_score(wiki['test'], text_column = 'comment', label_column = 'is_toxic')"
+    "wiki_test = pd.read_csv(wiki['test'])\n",
+    "wiki_model.score_auc(wiki_test['comment'], wiki_test['is_toxic'])"
    ]
   },
   {
@@ -269,7 +284,8 @@
     }
    ],
    "source": [
-    "debias_model.prep_data_and_score(debias['test'], text_column = 'comment', label_column = 'is_toxic')"
+    "debias_test = pd.read_csv(debias['test'])\n",
+    "debias_model.prep_data_and_score(debias_test['comment'], debias_test['is_toxic'])"
    ]
   },
   {
@@ -298,7 +314,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "version": "2.7.6"
   }
  },
  "nbformat": 4,

--- a/src/Train Toxicity Model.ipynb
+++ b/src/Train Toxicity Model.ipynb
@@ -99,7 +99,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Wikipedia Model"
+    "### Random model"
    ]
   },
   {
@@ -165,6 +165,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plain wikipedia model"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
@@ -224,6 +231,13 @@
    "source": [
     "wiki_test = pd.read_csv(wiki['test'])\n",
     "wiki_model.score_auc(wiki_test['comment'], wiki_test['is_toxic'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Debiased model"
    ]
   },
   {

--- a/src/model_tool.py
+++ b/src/model_tool.py
@@ -7,8 +7,8 @@ print('HELLO from model_tool')
 import cPickle
 import json
 import os
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 from keras.models import load_model
 from keras.preprocessing.text import Tokenizer
@@ -46,7 +46,7 @@ DEFAULT_HPARAMS = {
 
 
 def compute_auc(y_true, y_pred):
-    fpr, tpr, thresholds = metrics.roc_curve(y_true, y_pred)
+    fpr, tpr, _thresholds = metrics.roc_curve(y_true, y_pred)
     return metrics.auc(fpr, tpr)
 
 class ToxModel():
@@ -74,7 +74,7 @@ class ToxModel():
 
     def update_hparams(self, new_hparams):
         self.hparams.update(new_hparams)
-        
+
     def get_model_name(self):
         return self.model_name
 
@@ -93,54 +93,39 @@ class ToxModel():
                 '%s_hparams.json' % self.model_name), 'r') as f:
             self.hparams = json.load(f)
 
-    def prep_data(self, data_path, text_column, label_column = None, is_training = False):
-        """Loads the data from a csv.
-        
-        Args:
-            data_path: path to a csv file of the data to evaluate on.
-            text_column: column containing comment text in the csv.
-            label_column: column containing toxicity label in the csv. 
-                          If set to None, it is assumed the data is unlabelled.
-            is_training: Indicate if the data is training data on which to initialize
-                          the tokenizer.
-        
-        Returns:
-            text_data: A tokenized and padded text sequence as a model input.
-            text_labels: A set of labels corresponding to the input text.
-                         Returns None if no label_column is set.
-        """
-        
-        data = pd.read_csv(data_path)
-        text = data[text_column]
-        if is_training:
-            self.tokenizer = Tokenizer(num_words = self.hparams['max_num_words'])
-            self.tokenizer.fit_on_texts(text)
-            self.word_index = self.tokenizer.word_index
-            cPickle.dump(self.tokenizer, open(os.path.join(self.model_dir, '%s_tokenizer.pkl' % self.model_name), 'wb'))
-        text_sequences = self.tokenizer.texts_to_sequences(text)
+    def fit_and_save_tokenizer(self, texts):
+        """Fits tokenizer on texts and pickles the tokenizer state."""
+        self.tokenizer = Tokenizer(num_words = self.hparams['max_num_words'])
+        self.tokenizer.fit_on_texts(texts)
+        cPickle.dump(self.tokenizer, open(os.path.join(self.model_dir, '%s_tokenizer.pkl' % self.model_name), 'wb'))
 
-        text_data = pad_sequences(text_sequences, maxlen = self.hparams['max_sequence_length'])
-        
-        text_labels = None
-        if label_column:
-            text_labels = to_categorical(data[label_column])
-            
-        return text_data, text_labels
+    def prep_text(self, texts):
+        """Turns text into into padded sequences.
+
+        The tokenizer must be initialized before calling this method.
+
+        Args:
+            texts: Sequence of text strings.
+
+        Returns:
+            A tokenized and padded text sequence as a model input.
+        """
+        text_sequences = self.tokenizer.texts_to_sequences(texts)
+        return pad_sequences(text_sequences, maxlen=self.hparams['max_sequence_length'])
 
     def load_embeddings(self, embedding_path = DEFAULT_EMBEDDINGS_PATH):
-        self.embeddings_index = {}
-        f = open(embedding_path)
-        for line in f:
-            values = line.split()
-            word = values[0]
-            coefs = np.asarray(values[1:], dtype='float32')
-            self.embeddings_index[word] = coefs
-        f.close()
+        embeddings_index = {}
+        with open(embedding_path) as f:
+            for line in f:
+                values = line.split()
+                word = values[0]
+                coefs = np.asarray(values[1:], dtype='float32')
+                embeddings_index[word] = coefs
 
-        self.embedding_matrix = np.zeros((len(self.word_index) + 1, self.hparams['embedding_dim']))
+        self.embedding_matrix = np.zeros((len(self.tokenizer.word_index) + 1, self.hparams['embedding_dim']))
         num_words_in_embedding = 0
-        for word, i in self.word_index.items():
-            embedding_vector = self.embeddings_index.get(word)
+        for word, i in self.tokenizer.word_index.items():
+            embedding_vector = embeddings_index.get(word)
             if embedding_vector is not None:
                 num_words_in_embedding += 1
                 # words not found in embedding index will be all-zeros.
@@ -150,9 +135,18 @@ class ToxModel():
         self.model_name = model_name
         self.save_hparams(model_name)
 
+        train_data = pd.read_csv(training_data_path)
+        valid_data = pd.read_csv(validation_data_path)
+
+        print('Fitting tokenizer...')
+        self.fit_and_save_tokenizer(train_data[text_column])
+        print('Tokenizer fitted!')
+
         print('Preparing data...')
-        train_data, train_labels = self.prep_data(training_data_path, text_column, label_column, is_training = True)
-        valid_data, valid_labels = self.prep_data(validation_data_path, text_column, label_column)
+        train_text, train_labels = (self.prep_text(train_data[text_column]),
+                                    to_categorical(train_data[label_column]))
+        valid_text, valid_labels = (self.prep_text(valid_data[text_column]),
+                                    to_categorical(valid_data[label_column]))
         print('Data prepared!')
 
         print('Loading embeddings...')
@@ -164,18 +158,19 @@ class ToxModel():
         print('Training model...')
 
         save_path = os.path.join(self.model_dir, '%s_model.h5' % self.model_name)
-        callbacks = [ModelCheckpoint(save_path, save_best_only = True, verbose=self.hparams['verbose'])]
+        callbacks = [ModelCheckpoint(save_path, save_best_only=True, verbose=self.hparams['verbose'])]
 
         if self.hparams['stop_early']:
-            callbacks.append(EarlyStopping(min_delta=self.hparams['es_min_delta'], 
+            callbacks.append(EarlyStopping(min_delta=self.hparams['es_min_delta'],
                 monitor='val_loss', patience=self.hparams['es_patience'], verbose=self.hparams['verbose'], mode='auto'))
-        
-        self.model.fit(train_data, train_labels,
-          batch_size=self.hparams['batch_size'],
-          epochs=self.hparams['epochs'],
-          validation_data=(valid_data, valid_labels),
-          callbacks=callbacks,
-          verbose = 2)
+
+        self.model.fit(train_text,
+                       train_labels,
+                       batch_size=self.hparams['batch_size'],
+                       epochs=self.hparams['epochs'],
+                       validation_data=(valid_text, valid_labels),
+                       callbacks=callbacks,
+                       verbose=2)
         print('Model trained!')
         print('Best model saved to {}'.format(save_path))
         print('Loading best model from checkpoint...')
@@ -184,7 +179,7 @@ class ToxModel():
 
     def build_model(self):
         sequence_input = Input(shape=(self.hparams['max_sequence_length'],), dtype='int32')
-        embedding_layer = Embedding(len(self.word_index) + 1,
+        embedding_layer = Embedding(len(self.tokenizer.word_index) + 1,
                                     self.hparams['embedding_dim'],
                                     weights=[self.embedding_matrix],
                                     input_length=self.hparams['max_sequence_length'],
@@ -194,7 +189,7 @@ class ToxModel():
         x = embedded_sequences
         for filter_size, kernel_size, pool_size in zip(self.hparams['cnn_filter_sizes'], self.hparams['cnn_kernel_sizes'], self.hparams['cnn_pooling_sizes']):
             x = self.build_conv_layer(x, filter_size, kernel_size, pool_size)
-            
+
         x = Flatten()(x)
         x = Dropout(self.hparams['dropout_rate'])(x)
         # TODO(nthain): Parametrize the number and size of fully connected layers
@@ -215,18 +210,15 @@ class ToxModel():
             # TODO(nthain): This seems broken. Fix.
             output = GlobalMaxPooling1D()(output)
         return output
-            
-    def predict(self, data):
+
+    def predict(self, texts):
+        """Returns model predictions on texts."""
+        data = self.prep_text(texts)
         return self.model.predict(data)[:,1]
-    
-    def prep_data_and_predict(self, data_path, text_column, label_column = None):
-        data, labels = self.prep_data(data_path, text_column, label_column)
-        return self.predict(data)
-    
-    def prep_data_and_score(self, data_path, text_column, label_column = None):
-        data, labels = self.prep_data(data_path, text_column, label_column)
-        preds = self.predict(data)
-        return compute_auc(labels[:,1], preds)
-        
+
+    def score_auc(self, texts, labels):
+        preds = self.predict(texts)
+        return compute_auc(labels, preds)
+
     def summary():
         return self.model.summary()

--- a/src/model_tool.py
+++ b/src/model_tool.py
@@ -58,9 +58,10 @@ class ToxModel():
         self.model_name = model_name
         self.model = None
         self.tokenizer = None
-        self.hparams = DEFAULT_HPARAMS
-        if hparams:
-            self.update_hparams(hparams)
+        self.hparams = {}
+        if hparams is None:
+            hparams = DEFAULT_HPARAMS
+        self.update_hparams(hparams)
         if model_name:
             self.load_model_from_name(model_name)
         self.print_hparams()

--- a/src/model_tool.py
+++ b/src/model_tool.py
@@ -58,10 +58,9 @@ class ToxModel():
         self.model_name = model_name
         self.model = None
         self.tokenizer = None
-        self.hparams = {}
-        if hparams is None:
-            hparams = DEFAULT_HPARAMS
-        self.update_hparams(hparams)
+        self.hparams = DEFAULT_HPARAMS.copy()
+        if hparams:
+            self.update_hparams(hparams)
         if model_name:
             self.load_model_from_name(model_name)
         self.print_hparams()


### PR DESCRIPTION
Fixes bug with modifying the default hparams.

Removed prep_data_and_predict and prep_data_and_score methods. Replaced with just a "predict" method that takes a vector of texts and returns a vector of scores.