### PR TITLE
.gitignore fixes & added missing models dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@ virtualenv/
 data/toxicity_annotated_comments.tsv
 data/toxicity_annotations.tsv
 data/glove.6B
-models/
+models/*.json
+models/*.pkl
+data/
+*.pyc

--- a/models/README.md
+++ b/models/README.md
@@ -1,3 +1,3 @@
 This directory is used to store the generated model-related files:
-*   *hparams.json -- hyper parameters for models.
-*   *.pkl -- model files as python pickles.
+*   `*hparams.json` -- hyper parameters for models.
+*   `*.pkl` -- model files as python pickles.

--- a/models/README.md
+++ b/models/README.md
@@ -1,0 +1,3 @@
+This directory is used to store the generated model-related files:
+*   *hparams.json -- hyper parameters for models.
+*   *.pkl -- model files as python pickles.


### PR DESCRIPTION
The train ipython notebook doesn't run unless there is a models directory.

I've added the models directory to the repo, put a README in there, and updated the .gitignore to ignore the right stuff. 

I've also added the data directory to the .gitignore (we shouldn't have build-time downloaded data checked into github). 

I've also added .pyc files to gitignore - we don't want those accidentally checked in either. 