### PR TITLE
Update model_tool.py with datetime import

### DIFF
--- a/unintended_ml_bias/model_tool.py
+++ b/unintended_ml_bias/model_tool.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 import cPickle
+import datetime
 import json
 import os
 from keras.callbacks import EarlyStopping


### PR DESCRIPTION
I was updating my code to work with your latest changes and realized datetime never got imported for logging in the [score_dataset](https://github.com/conversationai/unintended-ml-bias-analysis/compare/master...rubinovitz:patch-1#diff-95d0d7ea657768083f703b10e72dc961L71) function