### PR TITLE
Fix pinned_auc_demo.ipynb

### DIFF
--- a/unintended_ml_bias/pinned_auc_demo.ipynb
+++ b/unintended_ml_bias/pinned_auc_demo.ipynb
@@ -287,7 +287,7 @@
       },
       "cell_type": "code",
       "source": [
-        "eq_diff = model_bias_analysis.per_subgroup_auc_diff_from_overall(df, terms, model_families, squared_error=True)\n",
+        "eq_diff = model_bias_analysis.per_subgroup_auc_diff_from_overall(df, terms, model_families, squared_error=True, normed_auc=False)\n",
         "# sort to guarantee deterministic output\n",
         "eq_diff.sort_values(by=['model_family'], inplace=True)\n",
         "eq_diff.reset_index(drop=True, inplace=True)\n",


### PR DESCRIPTION
Fix the demo by passing missed param when calling per_subgroup_auc_diff_from_overall()