### PR TITLE
Convert new_madlibber to pure PY3; lint

### DIFF
--- a/unintended_ml_bias/new_madlibber/format_helper.py
+++ b/unintended_ml_bias/new_madlibber/format_helper.py
@@ -1,17 +1,20 @@
 import re
 
+
 class FormatHelper():
+
   @classmethod
   def decompose_template_element(cls, template_element):
     s = template_element.split("_")
     for s_i in s:
-      if s_i == '' or len(s_i.split("|")) != 2:
-        raise ValueError("'{}' is not a valid template element".format(template_element))
+      if not s_i or len(s_i.split("|")) != 2:
+        raise ValueError(
+            "'{}' is not a valid template element".format(template_element))
     return s
 
   @classmethod
   def extract_template_elements(cls, phrase):
-    return re.findall('\{(.*?)\}',phrase)
+    return re.findall(r"\{(.*?)\}", phrase)
 
   @classmethod
   def construct_word_category(cls, column_name, column_value):

--- a/unintended_ml_bias/new_madlibber/madlibber.py
+++ b/unintended_ml_bias/new_madlibber/madlibber.py
@@ -1,7 +1,17 @@
-import re
 import csv
+import pandas as pd
+
+
+WORD_COL_NAME = "word"
+TYPE_COL_NAME = "type"
+IDENTITY_TYPE = "identity"
+CONNOTATION_COL_NAME = "connotation"
+NEUTRAL_CONNOTATION = "neutral"
+TOXIC_CONNOTATION = "toxic"
+
 
 class Madlibber(object):
+
   def __init__(self, path_helper, format_helper, word_helper):
     self.path_helper = path_helper
     self.format_helper = format_helper
@@ -11,74 +21,87 @@ class Madlibber(object):
     self.__template_word_categories = set([])
     self.__toxicity = set(["toxic", "nontoxic"])
 
+  def check_duplicates_sentence_templates(self):
+    df = pd.read_csv(self.path_helper.sentence_template_file)
+    if df[df.duplicated()]:
+      raise ValueError("Duplicate sentence templates")
+
   def load_sanity_check_templates_and_infer_word_categories(self):
     print("Loading templates, sanity checking and inferring word categories...")
-    f = open(self.path_helper.sentence_template_file, 'r')
+    self.check_duplicates_sentence_templates()
+    f = open(self.path_helper.sentence_template_file, "r")
     csv_f = csv.DictReader(f)
 
     for line in csv_f:
-      template = line['template']
-      toxicity = line['toxicity']
-      phrase = line['phrase']
+      template = line["template"]
+      toxicity = line["toxicity"]
+      phrase = line["phrase"]
       template_elements = self.format_helper.extract_template_elements(phrase)
 
-      if phrase == '':
+      if not phrase:
         continue
 
       if toxicity not in self.__toxicity:
         raise ValueError("'{}' is not a valid toxicity".format(toxicity))
 
-      if len(template_elements) == 0:
-        raise ValueError("Template '{}' does not require fill-in: '{}'".format(template, phrase))
+      if not template_elements:
+        raise ValueError("Template '{}' does not require fill-in: '{}'".format(
+            template, phrase))
 
       for t in template_elements:
-        template_element_word_categories = self.format_helper.decompose_template_element(t)
+        template_element_word_categories = (
+            self.format_helper.decompose_template_element(t))
         self.__template_word_categories.update(template_element_word_categories)
-        
+
       self.__templates.append((template, toxicity, phrase, template_elements))
       self.__template_elements.update(template_elements)
     f.close()
 
-    print("Inferred word categories: {}".format(", ".join(self.__template_word_categories)))
+    print("Inferred word categories: {}".format(", ".join(
+        self.__template_word_categories)))
     print("Done")
 
   def load_and_sanity_check_words(self):
     print("Loading word list...")
-    f = open(self.path_helper.word_file, 'r')
+    f = open(self.path_helper.word_file, "r")
     csv_f = csv.reader(f)
     header = next(csv_f)[:-1]  # Last column is the word itself
     words = []
     for line in csv_f:
       word = line[-1]  # Last column is the word itself
-      if word == '':
+      if not word:
         continue
       words.append(word)
-      unicode_word = word.decode('utf-8')
       for i, l in enumerate(line[:-1]):
         if l:
-          word_category = self.format_helper.construct_word_category(header[i], l)
-          self.word_helper.add_word(word_category, unicode_word)
+          word_category = self.format_helper.construct_word_category(
+              header[i], l)
+          self.word_helper.add_word(word_category, word)
     f.close()
     if len(set(words)) != len(words):
       raise ValueError("Duplicate words are not allowed.")
 
     for t in self.__template_word_categories:
       if t not in self.word_helper.word_categories:
-        raise ValueError("Template word_category '{}' is not represented in the word list".format(t))
+        raise ValueError("Template word_category '{}' is not represented "
+                         "in the word list".format(t))
 
-    print("Word categories: {}".format(", ".join(self.word_helper.word_categories)))
+    print("Word categories: {}".format(", ".join(
+        self.word_helper.word_categories)))
     print("Done")
 
   def display_statistics(self):
     print("Template statistics:")
     print("Total number of templates: {}".format(len(self.__templates)))
-    print("Total number of unique template elements to fill in: {}".format(len(self.__template_elements)))
+    print("Total number of unique template elements to fill in: {}".format(
+        len(self.__template_elements)))
     print("Word statistics:")
     template_element_word_counts = {}
     for i, te in enumerate(self.__template_elements):
       words = self.word_helper.get_template_element_words(te)
       template_element_word_counts[te] = len(words)
-      print("Template element {}: {}, Total number of words: {}".format(i, te, template_element_word_counts[te]))
+      print("Template element {}: {}, Total number of words: {}".format(
+          i, te, template_element_word_counts[te]))
     total = 0
     for t in self.__templates:
       template_elements = t[-1]
@@ -89,23 +112,26 @@ class Madlibber(object):
     print("Number of expected output lines: {}".format(total))
 
   def fill_templates(self):
-    fout = open(self.path_helper.output_file, 'w')
+    fout = open(self.path_helper.output_file, "w")
     csv_fout = csv.writer(fout)
-    csv_fout.writerow(['template','toxicity','phrase'])
+    csv_fout.writerow(["template", "toxicity", "phrase"])
 
     count = 0
     for template, toxicity, phrase, template_elements in self.__templates:
       template_count = 0
-      print("Working on template '{}' with toxicity '{}' and phrase '{}'".format(template, toxicity, phrase))
+      print(
+          "Working on template '{}' with toxicity '{}' and phrase '{}'".format(
+              template, toxicity, phrase))
 
-      unicode_phrase = phrase.decode('utf-8')
+      unicode_phrase = phrase.decode("utf-8")
       for words in self.__iterate_words(template_elements, 0):
         output_phrase = unicode_phrase.format(**words)
-        csv_fout.writerow([template, toxicity, output_phrase.encode('utf-8')])
+        csv_fout.writerow([template, toxicity, output_phrase.encode("utf-8")])
         count += 1
         template_count += 1
 
-      print("Output {} sentences for template '{}', toxicity '{}'".format(template_count, template, toxicity))
+      print("Output {} sentences for template '{}', toxicity '{}'".format(
+          template_count, template, toxicity))
     fout.close()
 
     print("Output {} total sentences".format(count))
@@ -117,6 +143,7 @@ class Madlibber(object):
       if is_last:
         yield {template_element: word}
       else:
-        for words in self.__iterate_words(template_elements, template_element_index+1):
+        for words in self.__iterate_words(template_elements,
+                                          template_element_index + 1):
           words[template_element] = word
           yield words

--- a/unintended_ml_bias/new_madlibber/path_helper.py
+++ b/unintended_ml_bias/new_madlibber/path_helper.py
@@ -1,6 +1,8 @@
 import os
 
+
 class PathHelper(object):
+
   def __init__(self, word_file, sentence_template_file, output_file):
     if not os.path.exists(word_file):
       raise IOError("Input word file '{}' does not exist!".format(word_file))
@@ -9,15 +11,19 @@ class PathHelper(object):
     self.word_file = word_file
 
     if not os.path.exists(sentence_template_file):
-      raise IOError("Input sentence template file '{}' does not exist!".format(sentence_template_file))
+      raise IOError("Input sentence template file '{}' does not exist!".format(
+          sentence_template_file))
     if not os.path.isfile(sentence_template_file):
-      raise IOError("Input sentence template  file '{}' is not a file!".format(sentence_template_file))
+      raise IOError("Input sentence template  file '{}' is not a file!".format(
+          sentence_template_file))
     self.sentence_template_file = sentence_template_file
 
-    if os.path.basename(output_file) == '':
-      raise IOError("Output file '{}' cannot be a directory.".format(output_file))
+    if not os.path.basename(output_file):
+      raise IOError(
+          "Output file '{}' cannot be a directory.".format(output_file))
     output_dirname = os.path.dirname(output_file)
     if not os.path.exists(output_dirname):
-      print("Output directory '{}' does not exist...creating".format(output_dirname))
+      print("Output directory '{}' does not exist...creating".format(
+          output_dirname))
       os.makedirs(output_dirname)
     self.output_file = output_file

--- a/unintended_ml_bias/new_madlibber/runner.py
+++ b/unintended_ml_bias/new_madlibber/runner.py
@@ -1,9 +1,10 @@
 import argparse
 
-from path_helper import PathHelper
-from format_helper import FormatHelper
-from word_helper import WordHelper
-from madlibber import Madlibber
+import format_helper
+import madlibber
+import path_helper
+import word_helper
+
 
 def parse_args():
   """Returns parsed arguments."""
@@ -25,18 +26,21 @@ def parse_args():
       help='The output file of filled in templates.')
   return parser.parse_args()
 
+
 def main():
   args = parse_args()
-  ph = PathHelper(args.input_words, args.input_sentence_templates, args.output_file)
-  wh = WordHelper(FormatHelper)
-  m = Madlibber(ph, FormatHelper, wh)
+  ph = path_helper.PathHelper(args.input_words, args.input_sentence_templates,
+                              args.output_file)
+  wh = word_helper.WordHelper(format_helper.FormatHelper)
+  m = madlibber.Madlibber(ph, format_helper.FormatHelper, wh)
   m.load_sanity_check_templates_and_infer_word_categories()
   m.load_and_sanity_check_words()
   m.display_statistics()
-  should_fill = raw_input("Do you wish to generate the sentences? [y/N]")
-  if should_fill == "y":
+  should_fill = input('Do you wish to generate the sentences? [y/N]')
+  if should_fill == 'y':
     m.fill_templates()
-  print("Done. Exiting...") 
+  print('Done. Exiting...')
+
 
 if __name__ == '__main__':
   main()

--- a/unintended_ml_bias/new_madlibber/word_helper.py
+++ b/unintended_ml_bias/new_madlibber/word_helper.py
@@ -1,4 +1,7 @@
+
+
 class WordHelper(object):
+
   def __init__(self, format_helper):
     self.format_helper = format_helper
     self.word_category_words = {}
@@ -8,7 +11,8 @@ class WordHelper(object):
     self.word_category_words[word_category].add(word)
 
   def get_template_element_words(self, template_element):
-    template_element_word_categories = self.format_helper.decompose_template_element(template_element)
+    template_element_word_categories = (
+        self.format_helper.decompose_template_element(template_element))
     words = self.word_category_words[template_element_word_categories[0]]
     for tewc in template_element_word_categories[1:]:
       words = words.intersection(self.word_category_words[tewc])


### PR DESCRIPTION
The only major change is at `self.word_helper.add_word(word_category, word)` in madlibber.py, where I dropped a decode; and changing the py2-era raw_input() to input() in one place.