### PR TITLE
Enable Travis testing for unintended_ml_bias repo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+
+python:
+  - "2.7"
+
+dist: trusty
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+
+script:
+  - bash run_tests.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ ipywidgets==7.0.0
 Jinja2==2.9.6
 jsonschema==2.6.0
 jupyter==1.0.0
-jupyter-client==5.1.0
+jupyter-client==5.2.0
 jupyter-console==5.2.0
 jupyter-core==4.4.0
 Keras==2.0.8
@@ -33,7 +33,7 @@ mock==2.0.0
 nbconvert==5.3.1
 nbformat==4.4.0
 notebook==5.7.8
-numpy==1.13.1
+numpy==1.16
 pandas==0.20.3
 pandocfilters==1.4.2
 pathlib2==2.3.0
@@ -41,14 +41,14 @@ pbr==3.1.1
 pexpect==4.2.1
 pickleshare==0.7.4
 prompt-toolkit==1.0.15
-protobuf==3.4.0
+protobuf==3.6.1
 ptyprocess==0.5.2
 Pygments==2.2.0
 pyparsing==2.2.0
 python-dateutil==2.6.1
 pytz==2017.2
 PyYAML==4.2b1
-pyzmq==16.0.2
+pyzmq==17
 qtconsole==4.3.1
 scandir==1.5
 scikit-learn==0.19.0
@@ -60,8 +60,8 @@ singledispatch==3.4.0.3
 six==1.10.0
 sklearn==0.0
 subprocess32==3.2.7
-tensorflow==1.15.4
-tensorflow-tensorboard==0.1.6
+tensorflow==1.15.0
+tensorboard==1.15.0
 terminado==0.8.1
 testpath==0.3.1
 tornado==4.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,8 +60,8 @@ singledispatch==3.4.0.3
 six==1.10.0
 sklearn==0.0
 subprocess32==3.2.7
-tensorflow==1.15.0
-tensorboard==1.15.0
+tensorflow==1.14.0
+tensorboard==1.14.0
 terminado==0.8.1
 testpath==0.3.1
 tornado==4.5.2

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+set -x
+
+pushd unintended_ml_bias
+python model_bias_analysis_test.py
+popd

--- a/unintended_ml_bias/model_bias_analysis.py
+++ b/unintended_ml_bias/model_bias_analysis.py
@@ -18,6 +18,8 @@ The functions in this file expect scored data in a data frame with columns:
     additional label columns from the original test data.
 """
 
+from __future__ import division
+
 import base64
 import io
 import os

--- a/unintended_ml_bias/model_bias_analysis_test.py
+++ b/unintended_ml_bias/model_bias_analysis_test.py
@@ -84,8 +84,9 @@ class ModelBiasAnalysisTest(tf.test.TestCase):
 
     pos_aseg, neg_aseg = mba.compute_average_squared_equality_gap(
         no_bias_df, 'subgroup', 'label', 'model_score')
-    self.assertAlmostEqual(pos_aseg, 0.33, places=1)
-    self.assertAlmostEqual(neg_aseg, 0.33, places=1)
+# TODO(dborkan): These assertions are failing at head.
+#    self.assertAlmostEqual(pos_aseg, 0.33, places=1)
+#    self.assertAlmostEqual(neg_aseg, 0.33, places=1)
 
   def test_subgroup_auc(self):
     df = self.make_biased_dataset()

--- a/unintended_ml_bias/model_bias_analysis_test.py
+++ b/unintended_ml_bias/model_bias_analysis_test.py
@@ -84,9 +84,8 @@ class ModelBiasAnalysisTest(tf.test.TestCase):
 
     pos_aseg, neg_aseg = mba.compute_average_squared_equality_gap(
         no_bias_df, 'subgroup', 'label', 'model_score')
-# TODO(dborkan): These assertions are failing at head.
-#    self.assertAlmostEqual(pos_aseg, 0.33, places=1)
-#    self.assertAlmostEqual(neg_aseg, 0.33, places=1)
+    self.assertAlmostEqual(pos_aseg, 0.33, places=1)
+    self.assertAlmostEqual(neg_aseg, 0.33, places=1)
 
   def test_subgroup_auc(self):
     df = self.make_biased_dataset()


### PR DESCRIPTION
This is currently only enabling the single unit test we have in this repo.
Which isn't passing.
For python 2.7.
sad.